### PR TITLE
Fix Spectacle crash caused by allOf

### DIFF
--- a/app/lib/common.js
+++ b/app/lib/common.js
@@ -101,7 +101,7 @@ var common = {
   	  ref = this.resolveSchemaReference(ref.$ref, root);
   	  return this.formatExampleProp(ref, root);
   	}
-    else if (ref.properties && ref.type == 'object') {
+    else if (ref.properties) {// && ref.type == 'object') {
       var obj = {};
       Object.keys(ref.properties).forEach(function(k) {
         obj[k] = that.formatExampleProp(ref.properties[k], root);


### PR DESCRIPTION
Swagger allows to use inheritance of definition types this way:
```
ChildType:
  type: object
  allOf:
    - $ref: #/definitions/Parent
    - properties
      ....
```
Spectacle crashed when this inheritance was used